### PR TITLE
Persist warming timers across restarts

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -51,6 +51,15 @@ namespace MaxTelegramBot
         private static readonly Dictionary<string, TimeSpan> _warmingRemainingByPhone = new Dictionary<string, TimeSpan>();
         private static readonly Dictionary<long, string> _resumeFreeByUser = new Dictionary<long, string>();
 
+        private static readonly string WarmingStateFile = "warming_state.json";
+        private static readonly object _warmingStateLock = new();
+
+        private class PersistedWarmingState
+        {
+            public Dictionary<string, double> Running { get; set; } = new();
+            public Dictionary<string, double> Paused { get; set; } = new();
+        }
+
         // Отслеживание последнего использованного номера для каждого пользователя
         private static readonly Dictionary<long, string> _lastUsedNumberByUser = new Dictionary<long, string>();
         
@@ -1070,6 +1079,8 @@ namespace MaxTelegramBot
                 // Инициализация бота
                 _botClient = new TelegramBotClient(_botToken);
 
+                LoadWarmingState();
+
                 // Запускаем Telegram polling в фоновом таске
                 using var cts = new CancellationTokenSource();
                 _cts = cts;
@@ -1652,6 +1663,7 @@ namespace MaxTelegramBot
                     if (left < TimeSpan.Zero) left = TimeSpan.Zero;
                     _warmingRemainingByPhone[phone] = left;
                     _warmingEndsByPhone.Remove(phone);
+                    SaveWarmingState();
                 }
 
                 // Закрываем браузер по этому номеру, затем чистим профиль
@@ -2293,6 +2305,7 @@ namespace MaxTelegramBot
                     }
                     _warmingEndsByPhone.Remove(phoneNumber);
                     _warmingRemainingByPhone.Remove(phoneNumber);
+                    SaveWarmingState();
                     _sessionDirByPhone.Remove(phoneNumber);
                     _lastUsedNumberByUser.Remove(callbackQuery.From.Id); // Очищаем последний использованный номер
 
@@ -3764,19 +3777,24 @@ namespace MaxTelegramBot
                 if (hasRemaining)
                 {
                     _warmingRemainingByPhone.Remove(phoneNumber);
+                    SaveWarmingState();
                 }
 
                 var endsAt = DateTime.UtcNow.Add(duration);
                 _warmingEndsByPhone[phoneNumber] = endsAt;
                 var cts = new CancellationTokenSource();
                 _warmingCtsByPhone[phoneNumber] = cts;
+                SaveWarmingState();
 
                 _ = Task.Run(async () =>
                 {
                     bool finishedNaturally = false;
                     try
                     {
-                        await _botClient.SendTextMessageAsync(chatId, $"🔥 Запущен прогрев для {phoneNumber}\n⏳ Осталось: {duration:hh\\:mm\\:ss}");
+                        if (chatId != 0)
+                        {
+                            try { await _botClient.SendTextMessageAsync(chatId, $"🔥 Запущен прогрев для {phoneNumber}\n⏳ Осталось: {duration:hh\\:mm\\:ss}"); } catch { }
+                        }
 
                         while (!cts.IsCancellationRequested)
                         {
@@ -3784,6 +3802,7 @@ namespace MaxTelegramBot
                             var left = endsAt - now;
                             if (left <= TimeSpan.Zero) { finishedNaturally = true; break; }
                             _warmingRemainingByPhone[phoneNumber] = left;
+                            SaveWarmingState();
                             await Task.Delay(TimeSpan.FromMinutes(1), cts.Token);
                         }
                     }
@@ -3795,17 +3814,18 @@ namespace MaxTelegramBot
                         if (finishedNaturally)
                         {
                             _warmingRemainingByPhone.Remove(phoneNumber);
-                            
+                            SaveWarmingState();
+
                             // Закрываем браузер для этого номера
-                            try 
-                            { 
+                            try
+                            {
                                 Console.WriteLine($"[WARMING] 🔄 Закрываю браузер для завершенного прогрева номера {phoneNumber}");
-                                
+
                                 // Получаем директорию сессии для этого номера
                                 if (_sessionDirByPhone.TryGetValue(phoneNumber, out var sessionDir) && !string.IsNullOrEmpty(sessionDir))
                                 {
                                     Console.WriteLine($"[WARMING] 📁 Найдена директория сессии: {sessionDir}");
-                                    
+
                                     // Пытаемся подключиться к браузеру и закрыть его
                                     try
                                     {
@@ -3817,7 +3837,7 @@ namespace MaxTelegramBot
                                     {
                                         Console.WriteLine($"[WARMING] ⚠️ Ошибка при закрытии браузера для номера {phoneNumber}: {ex.Message}");
                                     }
-                                    
+
                                     // Удаляем директорию сессии
                                     _sessionDirByPhone.Remove(phoneNumber);
                                     Console.WriteLine($"[WARMING] 🗑️ Директория сессии для номера {phoneNumber} удалена");
@@ -3831,8 +3851,11 @@ namespace MaxTelegramBot
                             {
                                 Console.WriteLine($"[WARMING] ❌ Ошибка при закрытии браузера для номера {phoneNumber}: {ex.Message}");
                             }
-                            
-                            try { await _botClient.SendTextMessageAsync(chatId, $"✅ Прогрев для {phoneNumber} завершен."); } catch { }
+
+                            if (chatId != 0)
+                            {
+                                try { await _botClient.SendTextMessageAsync(chatId, $"✅ Прогрев для {phoneNumber} завершен."); } catch { }
+                            }
                             try
                             {
                                 var norm = SupabaseService.NormalizePhoneForActive(phoneNumber);
@@ -3840,6 +3863,13 @@ namespace MaxTelegramBot
                                     await _supabaseService.DeleteActiveNumberByPhoneAsync(norm);
                             }
                             catch { }
+                        }
+                        else
+                        {
+                            var left = endsAt - DateTime.UtcNow;
+                            if (left < TimeSpan.Zero) left = TimeSpan.Zero;
+                            _warmingRemainingByPhone[phoneNumber] = left;
+                            SaveWarmingState();
                         }
                     }
                 });
@@ -3864,6 +3894,7 @@ namespace MaxTelegramBot
                 }
             }
             _warmingEndsByPhone.Remove(phoneNumber);
+            SaveWarmingState();
             
             // Закрываем браузер при принудительной остановке прогрева (если нужно)
             if (closeBrowser)
@@ -3945,6 +3976,68 @@ namespace MaxTelegramBot
                 line2 = "📊 Статус: Не активен";
             }
             return line1 + "\n" + line2;
+        }
+
+        private static void SaveWarmingState()
+        {
+            try
+            {
+                lock (_warmingStateLock)
+                {
+                    var running = new Dictionary<string, double>();
+                    foreach (var kv in _warmingEndsByPhone)
+                    {
+                        var left = kv.Value - DateTime.UtcNow;
+                        if (left > TimeSpan.Zero)
+                            running[kv.Key] = left.TotalSeconds;
+                    }
+
+                    var paused = new Dictionary<string, double>();
+                    foreach (var kv in _warmingRemainingByPhone)
+                    {
+                        if (kv.Value > TimeSpan.Zero)
+                            paused[kv.Key] = kv.Value.TotalSeconds;
+                    }
+
+                    var state = new PersistedWarmingState { Running = running, Paused = paused };
+                    var json = JsonConvert.SerializeObject(state);
+                    System.IO.File.WriteAllText(WarmingStateFile, json);
+                }
+            }
+            catch { }
+        }
+
+        private static void LoadWarmingState()
+        {
+            try
+            {
+                if (!System.IO.File.Exists(WarmingStateFile)) return;
+                var json = System.IO.File.ReadAllText(WarmingStateFile);
+                var state = JsonConvert.DeserializeObject<PersistedWarmingState>(json);
+                if (state == null) return;
+
+                if (state.Paused != null)
+                {
+                    foreach (var kv in state.Paused)
+                    {
+                        _warmingRemainingByPhone[kv.Key] = TimeSpan.FromSeconds(kv.Value);
+                    }
+                }
+
+                if (state.Running != null)
+                {
+                    foreach (var kv in state.Running)
+                    {
+                        var remain = TimeSpan.FromSeconds(kv.Value);
+                        if (remain > TimeSpan.Zero)
+                        {
+                            _warmingRemainingByPhone[kv.Key] = remain;
+                            StartWarmingTimer(kv.Key, 0);
+                        }
+                    }
+                }
+            }
+            catch { }
         }
         
         private static async Task SendRandomMessageAsync(MaxWebAutomation cdp)


### PR DESCRIPTION
## Summary
- persist remaining warming time to `warming_state.json`
- reload saved warming timers on startup and resume active ones
- save timer state whenever warming starts, stops or updates
- avoid timer reset when resuming without a chat
- store remaining time if a timer stops unexpectedly

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b4b18a503c832097051b085aeeed88