### PR TITLE
feat: allow purchasing custom warming hours

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -22,6 +22,8 @@ namespace MaxTelegramBot
         private static SupabaseService _supabaseService;
         private static CryptoPayService _cryptoPayService;
         private const decimal PricePerAccountUsdt = 0.50m;
+        private const decimal PricePerSixHoursUsdt = 0.50m;
+        private static decimal CalculateHoursPrice(int hours) => (PricePerSixHoursUsdt / 6m) * hours;
         private static CancellationTokenSource _cts; // для управляемого выключения
         private static bool _isShuttingDown = false;
         private static bool _maintenance = false; // режим обслуживания
@@ -41,6 +43,7 @@ namespace MaxTelegramBot
         private static readonly Dictionary<long, string> _userPhoneNumbers = new(); // Номера телефонов по пользователям
         private static readonly Dictionary<long, string> _lastSessionDirByUser = new Dictionary<long, string>();
         private static readonly HashSet<long> _awaitingPaymentQtyUserIds = new HashSet<long>();
+        private static readonly Dictionary<long, string> _awaitingHoursByUser = new();
         private static readonly Dictionary<string, string> _sessionDirByPhone = new Dictionary<string, string>();
 
         // Сессии для повторной проверки входа
@@ -1168,6 +1171,50 @@ namespace MaxTelegramBot
                                     }
                                 }
                             }
+
+                            var respTime = await http.GetAsync($"{_supabaseUrl}/rest/v1/time_payments?status=eq.pending&select=*");
+                            var jsonTime = await respTime.Content.ReadAsStringAsync();
+                            List<TimePayment> pendingTime;
+                            if (respTime.IsSuccessStatusCode)
+                            {
+                                try
+                                {
+                                    var tokenTime = Newtonsoft.Json.Linq.JToken.Parse(jsonTime);
+                                    pendingTime = tokenTime.Type == Newtonsoft.Json.Linq.JTokenType.Array
+                                        ? Newtonsoft.Json.JsonConvert.DeserializeObject<List<TimePayment>>(jsonTime) ?? new List<TimePayment>()
+                                        : new List<TimePayment>();
+                                }
+                                catch
+                                {
+                                    Console.WriteLine($"[Polling] Ошибка парсинга time_payments: {jsonTime}");
+                                    pendingTime = new List<TimePayment>();
+                                }
+                            }
+                            else
+                            {
+                                Console.WriteLine($"[Polling] Supabase time_payments error {respTime.StatusCode}: {jsonTime}");
+                                pendingTime = new List<TimePayment>();
+                            }
+                            foreach (var tp in pendingTime)
+                            {
+                                var status = await _cryptoPayService.GetInvoiceStatusAsync(tp.Hash);
+                                if (status == "paid")
+                                {
+                                    Console.WriteLine($"[Polling] Time invoice {tp.Hash} оплачен. Зачисляю {tp.Hours}ч на {tp.PhoneNumber}");
+                                    AddWarmingHours(tp.PhoneNumber, tp.Hours, tp.UserId);
+                                    await _supabaseService.MarkTimePaymentPaidAsync(tp.Hash);
+                                    try { await _botClient.SendTextMessageAsync(tp.UserId, $"✅ Оплата получена. Зачислено {tp.Hours}ч на {tp.PhoneNumber}."); } catch {}
+                                }
+                                else if (status == "expired" || (DateTime.UtcNow - tp.CreatedAt.ToUniversalTime()) > TimeSpan.FromMinutes(10))
+                                {
+                                    Console.WriteLine($"[Polling] Time invoice {tp.Hash} просрочен. Помечаю как canceled");
+                                    await _supabaseService.MarkTimePaymentCanceledAsync(tp.Hash);
+                                    if (tp.ChatId.HasValue && tp.MessageId.HasValue)
+                                    {
+                                        try { await _botClient.DeleteMessageAsync(tp.ChatId.Value, tp.MessageId.Value); } catch {}
+                                    }
+                                }
+                            }
                         }
                         catch (Exception ex)
                         {
@@ -1489,6 +1536,39 @@ namespace MaxTelegramBot
                 }
                 if (message.From != null) _awaitingPaymentQtyUserIds.Remove(message.From.Id);
             }
+            else if (message.From != null && _awaitingHoursByUser.TryGetValue(message.From.Id, out var phoneForHours)
+                     && int.TryParse(messageText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var hours) && hours >= 1 && hours <= 48)
+            {
+                var amountUsdt = CalculateHoursPrice(hours);
+                var description = $"Покупка {hours}ч для {phoneForHours}";
+                var invoice = await _cryptoPayService.CreateInvoiceAsync(amountUsdt, "USDT", description);
+                if (invoice != null && !string.IsNullOrEmpty(invoice.Url))
+                {
+                    var payKeyboard = new InlineKeyboardMarkup(new[]
+                    {
+                        new [] { InlineKeyboardButton.WithUrl("💰 Оплатить", invoice.Url) },
+                        new [] { InlineKeyboardButton.WithCallbackData("🏠 Главное меню", "main_menu") }
+                    });
+
+                    var paymentMsg = await botClient.SendTextMessageAsync(
+                        chatId: chatId,
+                        text: $"Счет создан на {amountUsdt:F2} USDT за {hours}ч для {phoneForHours}.\n\nОплатите по кнопке ниже.",
+                        replyMarkup: payKeyboard,
+                        cancellationToken: cancellationToken
+                    );
+
+                    await _supabaseService.CreateTimePaymentAsync(message.From.Id, phoneForHours, hours, amountUsdt, invoice.Hash, chatId, paymentMsg.MessageId);
+                }
+                else
+                {
+                    await botClient.SendTextMessageAsync(chatId, "❌ Не удалось создать счет. Попробуйте позже.", cancellationToken: cancellationToken);
+                }
+                _awaitingHoursByUser.Remove(message.From.Id);
+            }
+            else if (message.From != null && _awaitingHoursByUser.ContainsKey(message.From.Id))
+            {
+                await botClient.SendTextMessageAsync(chatId, "❌ Введите число часов от 1 до 48.", cancellationToken: cancellationToken);
+            }
             // Ввод номера телефона как раньше
             else if (message.From != null && (messageText.StartsWith("+") || (messageText.Length >= 10 && messageText.All(c => char.IsDigit(c) || c == '+' || c == '(' || c == ')' || c == '-' || c == ' '))) && !(message.From.Id == 1123842711 && messageText.Split(' ').Length == 2))
             {
@@ -1644,10 +1724,11 @@ namespace MaxTelegramBot
                 {
                     cardKb = new InlineKeyboardMarkup(new[]
                     {
-                        new [] { 
+                        new [] {
                             InlineKeyboardButton.WithCallbackData("🛑 Остановить", $"stop_warming:{phone}"),
                             InlineKeyboardButton.WithCallbackData("🗑️ Удалить", $"delete_account:{phone}")
                         },
+                        new [] { InlineKeyboardButton.WithCallbackData("🛒 Купить часы", $"buy_hours:{phone}") },
                         new [] { InlineKeyboardButton.WithCallbackData("← Назад", "my_accounts") }
                     });
                 }
@@ -1655,14 +1736,28 @@ namespace MaxTelegramBot
                 {
                     cardKb = new InlineKeyboardMarkup(new[]
                     {
-                        new [] { 
+                        new [] {
                             InlineKeyboardButton.WithCallbackData("▶️ Запустить", $"start_account:{phone}"),
                             InlineKeyboardButton.WithCallbackData("🗑️ Удалить", $"delete_account:{phone}")
                         },
+                        new [] { InlineKeyboardButton.WithCallbackData("🛒 Купить часы", $"buy_hours:{phone}") },
                         new [] { InlineKeyboardButton.WithCallbackData("← Назад", "my_accounts") }
                     });
                 }
                 await botClient.EditMessageTextAsync(chatId, messageId, cardText, replyMarkup: cardKb, cancellationToken: cancellationToken);
+                return;
+            }
+
+            // Покупка часов: buy_hours:<phone>
+            if (callbackQuery.Data != null && callbackQuery.Data.StartsWith("buy_hours:"))
+            {
+                var phone = callbackQuery.Data.Substring("buy_hours:".Length);
+                _awaitingHoursByUser[callbackQuery.From.Id] = phone;
+                var kb = new InlineKeyboardMarkup(new[]
+                {
+                    new [] { InlineKeyboardButton.WithCallbackData("❌ Отмена", $"acc:{phone}") }
+                });
+                await botClient.EditMessageTextAsync(chatId, messageId, $"⏱️ Введите количество часов для {phone} (1-48):", replyMarkup: kb, cancellationToken: cancellationToken);
                 return;
             }
 
@@ -3787,15 +3882,15 @@ namespace MaxTelegramBot
             }
         }
 
-        private static void StartWarmingTimer(string phoneNumber, long chatId)
+        private static void StartWarmingTimer(string phoneNumber, long chatId, TimeSpan? customDuration = null)
         {
             try
             {
                 // Сначала проверяем, есть ли сохраненный остаток времени
                 var hasRemaining = _warmingRemainingByPhone.TryGetValue(phoneNumber, out var remain);
-                var duration = hasRemaining && remain > TimeSpan.Zero
+                var duration = customDuration ?? (hasRemaining && remain > TimeSpan.Zero
                     ? remain
-                    : TimeSpan.FromHours(6);
+                    : TimeSpan.FromHours(6));
 
                 // Если уже идет прогрев — перезапускаем (браузер не закрываем)
                 StopWarmingTimer(phoneNumber, saveRemaining: false, closeBrowser: false); // Не сохраняем, так как уже знаем duration
@@ -3910,7 +4005,7 @@ namespace MaxTelegramBot
             }
             _warmingEndsByPhone.Remove(phoneNumber);
             SaveWarmingState();
-            
+
             // Закрываем браузер при принудительной остановке прогрева (если нужно)
             if (closeBrowser)
             {
@@ -3951,6 +4046,21 @@ namespace MaxTelegramBot
                         Console.WriteLine($"[WARMING] ❌ Ошибка при закрытии браузера для номера {phoneNumber} при остановке: {ex.Message}");
                     }
                 });
+            }
+        }
+
+        private static void AddWarmingHours(string phoneNumber, int hours, long chatId)
+        {
+            var extension = TimeSpan.FromHours(hours);
+            if (_warmingCtsByPhone.ContainsKey(phoneNumber) && _warmingEndsByPhone.TryGetValue(phoneNumber, out var ends))
+            {
+                var remaining = ends - DateTime.UtcNow;
+                if (remaining < TimeSpan.Zero) remaining = TimeSpan.Zero;
+                StartWarmingTimer(phoneNumber, chatId, remaining + extension);
+            }
+            else
+            {
+                StartWarmingTimer(phoneNumber, chatId, extension);
             }
         }
 

--- a/SupabaseService.cs
+++ b/SupabaseService.cs
@@ -68,6 +68,39 @@ namespace MaxTelegramBot
         public int? MessageId { get; set; }
     }
 
+    public class TimePayment
+    {
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        [JsonProperty("user_id")]
+        public long UserId { get; set; }
+
+        [JsonProperty("phone_number")]
+        public string PhoneNumber { get; set; } = string.Empty;
+
+        [JsonProperty("hash")]
+        public string Hash { get; set; } = string.Empty;
+
+        [JsonProperty("hours")]
+        public int Hours { get; set; }
+
+        [JsonProperty("amount_usdt")]
+        public decimal AmountUsdt { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; } = "pending";
+
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        [JsonProperty("chat_id")]
+        public long? ChatId { get; set; }
+
+        [JsonProperty("message_id")]
+        public int? MessageId { get; set; }
+    }
+
     public class ReferralEarning
     {
         [JsonProperty("id")]
@@ -814,6 +847,74 @@ namespace MaxTelegramBot
             catch (Exception ex)
             {
                 Console.WriteLine($"Ошибка CreatePaymentAsync: {ex.Message}");
+                return false;
+            }
+        }
+
+        public async Task<bool> CreateTimePaymentAsync(long userId, string phone, int hours, decimal amountUsdt, string hash, long chatId, int messageId)
+        {
+            try
+            {
+                var payload = new
+                {
+                    user_id = userId,
+                    phone_number = phone,
+                    hash = hash,
+                    hours = hours,
+                    amount_usdt = amountUsdt,
+                    status = "pending",
+                    created_at = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                    chat_id = chatId,
+                    message_id = messageId
+                };
+                var json = JsonConvert.SerializeObject(payload);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+                var response = await _httpClient.PostAsync($"{_supabaseUrl}/rest/v1/time_payments", content);
+                var resp = await response.Content.ReadAsStringAsync();
+                Console.WriteLine($"CreateTimePaymentAsync: {response.StatusCode} - {resp}");
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Ошибка CreateTimePaymentAsync: {ex.Message}");
+                return false;
+            }
+        }
+
+        public async Task<bool> MarkTimePaymentPaidAsync(string hash)
+        {
+            try
+            {
+                var payload = new { status = "paid" };
+                var json = JsonConvert.SerializeObject(payload);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+                var response = await _httpClient.PatchAsync($"{_supabaseUrl}/rest/v1/time_payments?hash=eq.{hash}", content);
+                var resp = await response.Content.ReadAsStringAsync();
+                Console.WriteLine($"MarkTimePaymentPaidAsync: {response.StatusCode} - {resp}");
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Ошибка MarkTimePaymentPaidAsync: {ex.Message}");
+                return false;
+            }
+        }
+
+        public async Task<bool> MarkTimePaymentCanceledAsync(string hash)
+        {
+            try
+            {
+                var payload = new { status = "canceled" };
+                var json = JsonConvert.SerializeObject(payload);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+                var response = await _httpClient.PatchAsync($"{_supabaseUrl}/rest/v1/time_payments?hash=eq.{hash}", content);
+                var resp = await response.Content.ReadAsStringAsync();
+                Console.WriteLine($"MarkTimePaymentCanceledAsync: {response.StatusCode} - {resp}");
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Ошибка MarkTimePaymentCanceledAsync: {ex.Message}");
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- add pricing helper for purchasing between 1 and 48 warming hours
- create time payment records and background polling to apply paid hours
- enable users to buy hours for specific numbers via inline menus

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b4be591aa883209725843ceb584c60