### PR TITLE
Stop auto warmup after payment

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4060,7 +4060,16 @@ namespace MaxTelegramBot
             }
             else
             {
-                StartWarmingTimer(phoneNumber, chatId, extension);
+                // Если прогрев не запущен, просто накапливаем оплаченные часы
+                if (_warmingRemainingByPhone.TryGetValue(phoneNumber, out var remain) && remain > TimeSpan.Zero)
+                {
+                    _warmingRemainingByPhone[phoneNumber] = remain + extension;
+                }
+                else
+                {
+                    _warmingRemainingByPhone[phoneNumber] = extension;
+                }
+                SaveWarmingState();
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid automatically launching warmup when payment is received

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b4d3e432548320bbc32cbaee5304a7