### PR TITLE
Fix warming timer persistence on restart

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4427,8 +4427,7 @@ namespace MaxTelegramBot
                         var remain = TimeSpan.FromSeconds(kv.Value);
                         if (remain > TimeSpan.Zero)
                         {
-                            _warmingRemainingByPhone[kv.Key] = remain;
-                            StartWarmingTimer(kv.Key, 0);
+                            StartWarmingTimer(kv.Key, 0, remain);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure warming timers restore remaining duration on startup

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b60aaff1b8832091c76180e2a7b364