### PR TITLE
Add bot info statistics

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2326,6 +2326,40 @@ namespace MaxTelegramBot
                     );
                     break;
 
+                case "info":
+                    var allUsers = await _supabaseService.GetAllUsersAsync();
+                    var totalAccounts = allUsers.Sum(u => u.PhoneNumbers?.Count ?? 0);
+                    var activeWarming = _warmingCtsByPhone.Count;
+                    var load = activeWarming switch
+                    {
+                        < 10 => "Низкая",
+                        < 50 => "Средняя",
+                        _ => "Высокая"
+                    };
+
+                    var infoMessage = "ℹ️ Информация о боте\n\n" +
+                                      "Atlantis Grev — сервис для безопасного прогрева аккаунтов MAX.\n" +
+                                      "Ниже отображается текущая статистика сервера.\n\n" +
+                                      "------\n" +
+                                      "Статистика сервера\n" +
+                                      $"Всего аккаунтов: {totalAccounts}\n" +
+                                      $"Прогревается сейчас: {activeWarming}\n" +
+                                      $"Нагрузка: {load}";
+
+                    var infoKeyboard = new InlineKeyboardMarkup(new[]
+                    {
+                        new [] { InlineKeyboardButton.WithCallbackData("🏠 Главное меню", "main_menu") }
+                    });
+
+                    await botClient.EditMessageTextAsync(
+                        chatId: chatId,
+                        messageId: messageId,
+                        text: infoMessage,
+                        replyMarkup: infoKeyboard,
+                        cancellationToken: cancellationToken
+                    );
+                    break;
+
                 case "support":
                     if (_userActiveTicket.ContainsKey(callbackQuery.From.Id))
                     {


### PR DESCRIPTION
## Summary
- show total accounts, active warming count and server load in the info section
- update info text to reference Atlantis Grev and MAX accounts only

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b7bb2e94d483209325cd15e30eb667