### PR TITLE
fix: click whatsapp login button

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -221,7 +221,7 @@ namespace MaxTelegramBot
 
 		public async Task<bool> ClickButtonByTextAsync(string containsText)
 		{
-			var expr = "(function(t){t=t.toLowerCase();var btns=Array.from(document.querySelectorAll('button'));for(var i=0;i<btns.length;i++){var el=btns[i];var txt=(el.textContent||'').trim().toLowerCase();if(txt.indexOf(t)>=0){el.click();return true;}}return false;})(" + JsonConvert.SerializeObject(containsText) + ")";
+			var expr = "(function(t){t=t.toLowerCase();var btns=Array.from(document.querySelectorAll(\"button,[role='button']\"));for(var i=0;i<btns.length;i++){var el=btns[i];var txt=(el.textContent||'').trim().toLowerCase();if(txt.indexOf(t)>=0){el.click();return true;}}return false;})(" + JsonConvert.SerializeObject(containsText) + ")";
 			var resp = await SendAsync("Runtime.evaluate", new JObject
 			{
 				["expression"] = expr,

--- a/Program.cs
+++ b/Program.cs
@@ -1158,20 +1158,36 @@ namespace MaxTelegramBot
                     try
                     {
                         await using var cdp = await MaxWebAutomation.ConnectAsync(userDir, "web.whatsapp.com");
-                        const string linkDeviceSelector = "a[href*='device']";
-                        if (await cdp.WaitForSelectorAsync(linkDeviceSelector, 5000))
+                        if (await cdp.ClickButtonByTextAsync("Войти по номеру телефона"))
                         {
-                            await cdp.ClickSelectorAsync(linkDeviceSelector);
-                            Console.WriteLine("[WA] Нажал на кнопку 'Связать устройство'");
+                            Console.WriteLine("[WA] Нажал на кнопку 'Войти по номеру телефона'");
+
+                            await Task.Delay(5000);
+                            var phoneInput = "input[aria-label='Введите свой номер телефона.']";
+                            if (await cdp.WaitForSelectorAsync(phoneInput))
+                            {
+                                await cdp.FocusSelectorAsync(phoneInput);
+                                await cdp.ClearInputAsync(phoneInput);
+                                var digits = new string((phone ?? "").Where(char.IsDigit).ToArray());
+                                if (digits.StartsWith("7")) digits = digits.Substring(1);
+                                if (digits.StartsWith("8")) digits = digits.Substring(1);
+                                if (digits.Length > 10) digits = digits.Substring(digits.Length - 10);
+                                await cdp.TypeTextAsync(digits);
+                                Console.WriteLine($"[WA] Ввёл номер {digits}");
+                            }
+                            else
+                            {
+                                Console.WriteLine("[WA] Поле ввода номера не найдено");
+                            }
                         }
                         else
                         {
-                            Console.WriteLine("[WA] Кнопка 'Связать устройство' не найдена");
+                            Console.WriteLine("[WA] Кнопка 'Войти по номеру телефона' не найдена");
                         }
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"[WA] Не удалось нажать на 'Связать устройство': {ex.Message}");
+                        Console.WriteLine($"[WA] Не удалось нажать на 'Войти по номеру телефона': {ex.Message}");
                     }
                 }
                 else


### PR DESCRIPTION
## Summary
- handle div-based buttons when clicking by text
- click "Войти по номеру телефона" on WhatsApp Web instead of outdated link
- wait and fill phone input on WhatsApp login
- normalize phone number before typing into WhatsApp login

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b845d8104483209249d9f976390608