### PR TITLE
Autofill WhatsApp login after number-based login click

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1161,6 +1161,22 @@ namespace MaxTelegramBot
                         if (await cdp.ClickButtonByTextAsync("Войти по номеру телефона"))
                         {
                             Console.WriteLine("[WA] Нажал на кнопку 'Войти по номеру телефона'");
+
+                            // Ждём появления поля ввода и вводим номер без первой цифры
+                            await Task.Delay(5000);
+                            const string phoneInputSelector = "input[aria-label='Введите свой номер телефона.']";
+                            if (await cdp.WaitForSelectorAsync(phoneInputSelector))
+                            {
+                                var digitsForLogin = safePhone.StartsWith("7") ? safePhone.Substring(1) : safePhone;
+                                await cdp.FocusSelectorAsync(phoneInputSelector);
+                                await cdp.ClearInputAsync(phoneInputSelector);
+                                await cdp.TypeTextAsync(digitsForLogin);
+                                Console.WriteLine($"[WA] Ввел номер {digitsForLogin}");
+                            }
+                            else
+                            {
+                                Console.WriteLine("[WA] Поле ввода номера не найдено");
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
## Summary
- wait 5 seconds after clicking “Войти по номеру телефона” in WhatsApp web automation
- auto-fill phone number without leading digit in the login input

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b84b8486208320bc3d4abbc96d48d6