### PR TITLE
Remove redundant WhatsApp login button log

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1178,10 +1178,6 @@ namespace MaxTelegramBot
                                 Console.WriteLine("[WA] Поле ввода номера не найдено");
                             }
                         }
-                        else
-                        {
-                            Console.WriteLine("[WA] Кнопка 'Войти по номеру телефона' не найдена");
-                        }
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
## Summary
- remove console log that warned when the 'Войти по номеру телефона' button was missing

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b84da0ecb48320841939692848b4e7