### PR TITLE
Handle new WhatsApp phone input field

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -137,15 +137,17 @@ namespace MaxTelegramBot
 			});
 		}
 
-		public async Task ClearInputAsync(string cssSelector)
-		{
-			var expr = "(function(){var el=document.querySelector('" + EscapeJs(cssSelector) + "'); if(el){el.value=''; el.dispatchEvent(new Event('input',{bubbles:true}));}})()";
-			await SendAsync("Runtime.evaluate", new JObject
-			{
-				["expression"] = expr,
-				["awaitPromise"] = false
-			});
-		}
+                public async Task ClearInputAsync(string cssSelector)
+                {
+                        var expr = "(function(){var el=document.querySelector('" + EscapeJs(cssSelector) + "');" +
+                                   " if(el){if('value' in el){el.value='';}else{el.textContent='';}" +
+                                   " el.dispatchEvent(new Event('input',{bubbles:true}));}})()";
+                        await SendAsync("Runtime.evaluate", new JObject
+                        {
+                                ["expression"] = expr,
+                                ["awaitPromise"] = false
+                        });
+                }
 
 		public async Task ClearInputAsync()
 		{

--- a/Program.cs
+++ b/Program.cs
@@ -1169,7 +1169,10 @@ namespace MaxTelegramBot
                             var possibleSelectors = new[]
                             {
                                 "input[aria-label='Введите свой номер телефона.']",
-                                "input[type='tel']"
+                                "input[type='tel']",
+                                "div[contenteditable='true'][data-testid='phone-number-input']",
+                                "div[contenteditable='true'][data-tab='6']",
+                                "div[role='textbox'][title*='номер']"
                             };
                             foreach (var selector in possibleSelectors)
                             {


### PR DESCRIPTION
## Summary
- clear contenteditable elements when resetting inputs
- look for newer selectors when filling WhatsApp phone number

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b865dc543083208e759605782b3d76