### PR TITLE
Use JavaScript for WhatsApp phone entry

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -149,10 +149,22 @@ namespace MaxTelegramBot
                         });
                 }
 
-		public async Task ClearInputAsync()
-		{
-			await SendAsync("Input.clear", new JObject());
-		}
+                public async Task SetInputValueAsync(string cssSelector, string value)
+                {
+                        var expr = "(function(){var el=document.querySelector('" + EscapeJs(cssSelector) + "');" +
+                                   " if(el){if('value' in el){el.value='" + EscapeJs(value) + "';}else{el.textContent='" + EscapeJs(value) + "';}" +
+                                   " el.dispatchEvent(new Event('input',{bubbles:true})); return true;} return false;})()";
+                        await SendAsync("Runtime.evaluate", new JObject
+                        {
+                                ["expression"] = expr,
+                                ["awaitPromise"] = false
+                        });
+                }
+
+                public async Task ClearInputAsync()
+                {
+                        await SendAsync("Input.clear", new JObject());
+                }
 
 		public async Task TypeTextAsync(string text)
 		{

--- a/Program.cs
+++ b/Program.cs
@@ -1186,10 +1186,8 @@ namespace MaxTelegramBot
                             if (phoneInputSelector != null)
                             {
                                 var digitsForLogin = safePhone.StartsWith("7") ? safePhone.Substring(1) : safePhone;
-                                await cdp.ClearInputAsync(phoneInputSelector);
-                                await cdp.FocusSelectorAsync(phoneInputSelector);
-                                await cdp.TypeTextAsync(digitsForLogin);
-                                Console.WriteLine($"[WA] Ввел номер {digitsForLogin}");
+                                await cdp.SetInputValueAsync(phoneInputSelector, digitsForLogin);
+                                Console.WriteLine($"[WA] Ввел номер {digitsForLogin} через JavaScript");
                             }
                             else
                             {


### PR DESCRIPTION
## Summary
- Add `SetInputValueAsync` helper to fill inputs using JavaScript
- Use JavaScript to enter WhatsApp phone numbers, removing previous typing steps

## Testing
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68b8682eaac0832097fb60de02a95ffa