### PR TITLE
Fix WhatsApp phone number input selector

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1164,26 +1164,10 @@ namespace MaxTelegramBot
 
                             // Ждём появления поля ввода и вводим номер без первой цифры
                             await Task.Delay(5000);
-                            // Новый интерфейс WhatsApp может использовать другое поле ввода
-                            string? phoneInputSelector = null;
-                            var possibleSelectors = new[]
-                            {
-                                "input[aria-label='Введите свой номер телефона.']",
-                                "input[type='tel']",
-                                "div[contenteditable='true'][data-testid='phone-number-input']",
-                                "div[contenteditable='true'][data-tab='6']",
-                                "div[role='textbox'][title*='номер']"
-                            };
-                            foreach (var selector in possibleSelectors)
-                            {
-                                if (await cdp.WaitForSelectorAsync(selector))
-                                {
-                                    phoneInputSelector = selector;
-                                    break;
-                                }
-                            }
+                            const string phoneInputSelector =
+                                "div.x1n2onr6.xqv4dci.x1aazizy.xd3ty66.xcicffo.x1vktgvc.x1qx5ct2.xe7vic5.x178xt8z.x1lun4ml.xso031l.xpilrb4.x13fuv20.x18b5jzi.x1q0q8m5.x1t7ytsu.x1rl75mt.x19t5iym.xz7t8uv.x13xmedi.xy2seqb.x12sz9sg.xwm8nch.xxkxxek > div.x1n2onr6 > form > input.selectable-text.x1n2onr6.xy9n6vp.x1n327nk.xh8yej3.x972fbf.x10w94by.x1qhh985.x14e42zd.xjbqb8w.x1uvtmcs.x1jchvi3.xss6m8b.xexx8yu.xyri2b.x18d9i69.x1c1uobl";
 
-                            if (phoneInputSelector != null)
+                            if (await cdp.WaitForSelectorAsync(phoneInputSelector))
                             {
                                 var digitsForLogin = safePhone.StartsWith("7") ? safePhone.Substring(1) : safePhone;
                                 await cdp.SetInputValueAsync(phoneInputSelector, digitsForLogin);
@@ -1191,7 +1175,7 @@ namespace MaxTelegramBot
                             }
                             else
                             {
-                                Console.WriteLine("[WA] Поле ввода номера не найдено");
+                                Console.WriteLine("[WA] Поле ввода номера не найдено по селектору");
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- use explicit CSS selector for WhatsApp phone input
- remove outdated fallback selectors

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b86a42cad08320b71e8605e9dd3a71