### PR TITLE
Add detailed logging for WhatsApp number input

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -149,16 +149,18 @@ namespace MaxTelegramBot
                         });
                 }
 
-                public async Task SetInputValueAsync(string cssSelector, string value)
+                public async Task<bool> SetInputValueAsync(string cssSelector, string value)
                 {
                         var expr = "(function(){var el=document.querySelector('" + EscapeJs(cssSelector) + "');" +
                                    " if(el){if('value' in el){el.value='" + EscapeJs(value) + "';}else{el.textContent='" + EscapeJs(value) + "';}" +
                                    " el.dispatchEvent(new Event('input',{bubbles:true})); return true;} return false;})()";
-                        await SendAsync("Runtime.evaluate", new JObject
+                        var resp = await SendAsync("Runtime.evaluate", new JObject
                         {
                                 ["expression"] = expr,
-                                ["awaitPromise"] = false
+                                ["awaitPromise"] = false,
+                                ["returnByValue"] = true
                         });
+                        return resp?["result"]?["value"]?.Value<bool?>() == true;
                 }
 
                 public async Task ClearInputAsync()

--- a/Program.cs
+++ b/Program.cs
@@ -1158,7 +1158,8 @@ namespace MaxTelegramBot
                     try
                     {
                         await using var cdp = await MaxWebAutomation.ConnectAsync(userDir, "web.whatsapp.com");
-                        if (await cdp.ClickButtonByTextAsync("Войти по номеру телефона"))
+                        var clicked = await cdp.ClickButtonByTextAsync("Войти по номеру телефона");
+                        if (clicked)
                         {
                             Console.WriteLine("[WA] Нажал на кнопку 'Войти по номеру телефона'");
 
@@ -1167,16 +1168,29 @@ namespace MaxTelegramBot
                             const string phoneInputSelector =
                                 "div.x1n2onr6.xqv4dci.x1aazizy.xd3ty66.xcicffo.x1vktgvc.x1qx5ct2.xe7vic5.x178xt8z.x1lun4ml.xso031l.xpilrb4.x13fuv20.x18b5jzi.x1q0q8m5.x1t7ytsu.x1rl75mt.x19t5iym.xz7t8uv.x13xmedi.xy2seqb.x12sz9sg.xwm8nch.xxkxxek > div.x1n2onr6 > form > input.selectable-text.x1n2onr6.xy9n6vp.x1n327nk.xh8yej3.x972fbf.x10w94by.x1qhh985.x14e42zd.xjbqb8w.x1uvtmcs.x1jchvi3.xss6m8b.xexx8yu.xyri2b.x18d9i69.x1c1uobl";
 
-                            if (await cdp.WaitForSelectorAsync(phoneInputSelector))
+                            var found = await cdp.WaitForSelectorAsync(phoneInputSelector);
+                            if (found)
                             {
+                                Console.WriteLine("[WA] Поле ввода номера найдено");
                                 var digitsForLogin = safePhone.StartsWith("7") ? safePhone.Substring(1) : safePhone;
-                                await cdp.SetInputValueAsync(phoneInputSelector, digitsForLogin);
-                                Console.WriteLine($"[WA] Ввел номер {digitsForLogin} через JavaScript");
+                                var success = await cdp.SetInputValueAsync(phoneInputSelector, digitsForLogin);
+                                if (success)
+                                {
+                                    Console.WriteLine($"[WA] Ввел номер {digitsForLogin} через JavaScript");
+                                }
+                                else
+                                {
+                                    Console.WriteLine($"[WA] Не удалось ввести номер {digitsForLogin} через JavaScript");
+                                }
                             }
                             else
                             {
-                                Console.WriteLine("[WA] Поле ввода номера не найдено по селектору");
+                                Console.WriteLine($"[WA] Поле ввода номера не найдено по селектору: {phoneInputSelector}");
                             }
+                        }
+                        else
+                        {
+                            Console.WriteLine("[WA] Кнопка 'Войти по номеру телефона' не найдена");
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
## Summary
- log steps while opening WhatsApp Web and populating phone number
- return success flag from SetInputValueAsync for debugging

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b86e54bf408320bf914aedb42acb8c