### PR TITLE
refactor: adjust whatsapp login selector logic

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -234,6 +234,26 @@ namespace MaxTelegramBot
                         return false;
                 }
 
+                public async Task<bool> WaitForXPathAsync(string xpath, int timeoutMs = 15000, int pollMs = 250)
+                {
+                        var sw = Stopwatch.StartNew();
+                        var escaped = EscapeJs(xpath);
+                        while (sw.ElapsedMilliseconds < timeoutMs)
+                        {
+                                var expr = "(function(p){try{var n=document.evaluate(p,document,null,XPathResult.FIRST_ORDERED_NODE_TYPE,null).singleNodeValue;return n!=null;}catch(e){return false;}})('" + escaped + "')";
+                                var resp = await SendAsync("Runtime.evaluate", new JObject
+                                {
+                                        ["expression"] = expr,
+                                        ["awaitPromise"] = false,
+                                        ["returnByValue"] = true
+                                });
+                                var result = resp?["result"]?["value"]?.Value<bool?>();
+                                if (result == true) return true;
+                                await Task.Delay(pollMs);
+                        }
+                        return false;
+                }
+
 		public async Task<bool> WaitForBodyTextContainsAsync(string substring, int timeoutMs = 15000, int pollMs = 250)
 		{
 			var sw = Stopwatch.StartNew();


### PR DESCRIPTION
## Summary
- remove automatic phone input for WhatsApp login
- add detection for provided XPath selectors
- support XPath polling in automation helper

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b8c068cfec8320b8b394f8ed5f92e1