### PR TITLE
Fix WhatsApp phone input selection

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1163,34 +1163,21 @@ namespace MaxTelegramBot
                         await cdp.ClickButtonByTextAsync("Войти по номеру телефона");
                         Console.WriteLine("[WA] Нажал на кнопку 'Войти по номеру телефона'");
 
-                        // Ждём появления поля ввода
+                        // Ждём появления поля ввода и вводим номер
                         await Task.Delay(5000);
-                        var selectors = new[]
+                        var inputSelector = "input.selectable-text.x1n2onr6.xy9n6vp.x1n327nk.xh8yej3.x972fbf.x10w94by.x1qhh985.x14e42zd.xjbqb8w.x1uvtmcs.x1jchvi3.xss6m8b.xexx8yu.xyri2b.x18d9i69.x1c1uobl";
+                        var found = await cdp.WaitForSelectorAsync(inputSelector, timeoutMs: 10000);
+                        if (found)
                         {
-                            "//*[@id=\"app\"]/div[1]/div[2]/div[2]/div[2]/div/div/div[3]/div[1]/div[2]/div/div/div/form/input",
-                            "//*[@id=\"app\"]/div[1]/div[2]/div[2]/div[2]/div/div/div[3]/div[1]/div[2]/div/div/div/form/input"
-                        };
-
-                        var anyFound = false;
-                        foreach (var xpath in selectors)
-                        {
-                            var isFound = await cdp.WaitForXPathAsync(xpath, timeoutMs: 10000);
-                            if (isFound)
-                            {
-                                Console.WriteLine($"[WA] Обнаружено поле ввода по селектору: {xpath}");
-                                anyFound = true;
-                            }
-                            else
-                            {
-                                Console.WriteLine($"[WA] Поле ввода не найдено по селектору: {xpath}");
-                            }
+                            Console.WriteLine($"[WA] Обнаружено поле ввода по селектору: {inputSelector}");
+                            await cdp.SetInputValueAsync(inputSelector, phone);
+                            Console.WriteLine($"[WA] Ввёл номер {phone}");
                         }
-
-                        if (!anyFound)
+                        else
                         {
-                            Console.WriteLine("[WA] Поле ввода номера не найдено ни по одному из селекторов");
+                            Console.WriteLine($"[WA] Поле ввода номера не найдено по селектору: {inputSelector}");
                         }
-                    }
+                        }
                     catch (Exception ex)
                     {
                         Console.WriteLine($"[WA] Не удалось нажать на 'Войти по номеру телефона': {ex.Message}");


### PR DESCRIPTION
## Summary
- simplify WhatsApp phone number login by using a single CSS selector
- automatically populate the phone input with the provided number

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b986fcee008320816b63e7c34c3bcf