### PR TITLE
Fix WhatsApp phone input automation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1170,9 +1170,12 @@ namespace MaxTelegramBot
                         if (found)
                         {
                             Console.WriteLine($"[WA] Обнаружено поле ввода по селектору: {inputSelector}");
-                            await cdp.FocusSelectorAsync(inputSelector);
-                            await cdp.ClearInputAsync(inputSelector);
-                            await cdp.TypeTextAsync(phone);
+                            var success = await cdp.SetInputValueAsync(inputSelector, phone);
+                            if (!success)
+                            {
+                                await cdp.FocusSelectorAsync(inputSelector);
+                                await cdp.TypeTextAsync(phone);
+                            }
                             Console.WriteLine($"[WA] Ввёл номер {phone}");
                         }
                         else


### PR DESCRIPTION
## Summary
- ensure WhatsApp phone field is populated by trying SetInputValue and falling back to keyboard typing

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68ba0e11bcec832085dab50d50a3861c