### PR TITLE
Specify WhatsApp Web version for warm-up

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -28,6 +28,9 @@ namespace MaxTelegramBot
         private static CancellationTokenSource _cts; // для управляемого выключения
         private static bool _isShuttingDown = false;
         private static bool _maintenance = false; // режим обслуживания
+
+        // Целевая версия WhatsApp Web
+        private const string WhatsAppWebVersion = "2.3000.1017054665";
         
         // Данные Supabase
         private static string _supabaseUrl = "https://jlsmbiebfqqgncihdfki.supabase.co";
@@ -1144,7 +1147,7 @@ namespace MaxTelegramBot
 
                 if (!string.IsNullOrEmpty(chrome))
                 {
-                    var args = $"--new-window --user-data-dir=\"{userDir}\" --remote-debugging-port=0 --user-agent=\"{userAgent}\" --disable-gpu --disable-software-rasterizer --disable-dev-shm-usage --disable-web-security --disable-features=VizDisplayCompositor --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-renderer-backgrounding --disable-ipc-flooding-protection --memory-pressure-off --max_old_space_size=128 --disable-extensions --disable-plugins --disable-images --disable-animations --disable-video --disable-audio --disable-webgl --disable-canvas-aa --disable-2d-canvas-clip-aa --disable-accelerated-2d-canvas --disable-accelerated-jpeg-decoding --disable-accelerated-mjpeg-decode --disable-accelerated-video-decode --disable-accelerated-video-encode --disable-gpu-sandbox --disable-software-rasterizer --disable-background-networking --disable-default-apps --disable-sync --disable-translate --hide-scrollbars --mute-audio --no-first-run --no-default-browser-check --no-sandbox --disable-setuid-sandbox https://web.whatsapp.com/";
+                    var args = $"--new-window --user-data-dir=\"{userDir}\" --remote-debugging-port=0 --user-agent=\"{userAgent}\" --disable-gpu --disable-software-rasterizer --disable-dev-shm-usage --disable-web-security --disable-features=VizDisplayCompositor --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-renderer-backgrounding --disable-ipc-flooding-protection --memory-pressure-off --max_old_space_size=128 --disable-extensions --disable-plugins --disable-images --disable-animations --disable-video --disable-audio --disable-webgl --disable-canvas-aa --disable-2d-canvas-clip-aa --disable-accelerated-2d-canvas --disable-accelerated-jpeg-decoding --disable-accelerated-mjpeg-decode --disable-accelerated-video-decode --disable-accelerated-video-encode --disable-gpu-sandbox --disable-software-rasterizer --disable-background-networking --disable-default-apps --disable-sync --disable-translate --hide-scrollbars --mute-audio --no-first-run --no-default-browser-check --no-sandbox --disable-setuid-sandbox https://web.whatsapp.com/?webVersion={WhatsAppWebVersion}";
                     var psi = new ProcessStartInfo
                     {
                         FileName = chrome,
@@ -1201,7 +1204,7 @@ namespace MaxTelegramBot
                 }
                 else
                 {
-                    var psi = new ProcessStartInfo { FileName = "https://web.whatsapp.com/", UseShellExecute = true };
+                    var psi = new ProcessStartInfo { FileName = $"https://web.whatsapp.com/?webVersion={WhatsAppWebVersion}", UseShellExecute = true };
                     Process.Start(psi);
                     Console.WriteLine($"[WA] Chrome не найден, открыл URL в браузере по умолчанию для {phone}");
                 }


### PR DESCRIPTION
## Summary
- enforce WhatsApp Web version 2.3000.1017054665 via constant
- append version to WhatsApp Web URL when launching Chrome or default browser

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68ba2303a9ec8320a7506c2600875356