### PR TITLE
Use simplified selector for verification code retrieval

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1194,21 +1194,17 @@ namespace MaxTelegramBot
                         Console.WriteLine("[WA] Нажал кнопку 'Далее'");
 
                         await Task.Delay(10000);
-                        const string codeSelector = "span.x2b8uid.xk50ysn.x1aueamr.x1jzgpr8.xzwifym";
+                        const string codeSelector = "span.x2b8uid";
                         string code = string.Empty;
                         try
                         {
-                                var codeFound = await cdp.WaitForSelectorAsync(codeSelector, 15000);
-                                if (codeFound)
+                                var resp = await cdp.SendAsync("Runtime.evaluate", new JObject
                                 {
-                                        var resp = await cdp.SendAsync("Runtime.evaluate", new JObject
-                                        {
-                                                ["expression"] = $"Array.from(document.querySelectorAll('{codeSelector}')).map(e=>e.textContent.trim()).join('').slice(0,8)",
-                                                ["returnByValue"] = true,
-                                                ["awaitPromise"] = true
-                                        });
-                                        code = resp?["result"]?["value"]?.ToString() ?? string.Empty;
-                                }
+                                        ["expression"] = $"Array.from(document.querySelectorAll('{codeSelector}')).map(e=>e.textContent.trim()).join('').slice(0,8)",
+                                        ["returnByValue"] = true,
+                                        ["awaitPromise"] = true
+                                });
+                                code = resp?["result"]?["value"]?.ToString() ?? string.Empty;
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
## Summary
- Use `span.x2b8uid` as the code selector
- Retrieve code without waiting for selector presence

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bb4ebaba048320930b81a0d6469e4e