### PR TITLE
Use specific span class selector to extract WhatsApp code

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1202,14 +1202,14 @@ namespace MaxTelegramBot
                                 {
                                         var resp = await cdp.SendAsync("Runtime.evaluate", new JObject
                                         {
-                                                ["expression"] = "document.body.innerText",
+                                                ["expression"] = "document.body.innerHTML",
                                                 ["returnByValue"] = true,
                                                 ["awaitPromise"] = true
                                         });
-                                        var bodyText = resp?["result"]?["value"]?.ToString() ?? string.Empty;
-                                        var normalized = Regex.Replace(bodyText, @"\s+", "");
-                                        var match = Regex.Match(normalized, @"[A-Z0-9]{4}-[A-Z0-9]{4}");
-                                        code = match.Success ? match.Value : string.Empty;
+                                        var bodyHtml = resp?["result"]?["value"]?.ToString() ?? string.Empty;
+                                        var pattern = @"<span[^>]*class=\"[^\"]*x2b8uid[^\"]*\"[^>]*>(.*?)</span>";
+                                        var match = Regex.Match(bodyHtml, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                                        code = match.Success ? match.Groups[1].Value.Trim() : string.Empty;
                                         if (string.IsNullOrEmpty(code))
                                                 await Task.Delay(500);
                                 }


### PR DESCRIPTION
## Summary
- Extract WhatsApp verification code by matching a span with class `x2b8uid` in the page's HTML.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb57a188888320bb0291bd40a32722