### PR TITLE
Fix regex pattern string literal

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1207,7 +1207,7 @@ namespace MaxTelegramBot
                                                 ["awaitPromise"] = true
                                         });
                                         var bodyHtml = resp?["result"]?["value"]?.ToString() ?? string.Empty;
-                                        var pattern = @"<span[^>]*class=\"[^\"]*x2b8uid[^\"]*\"[^>]*>(.*?)</span>";
+                                        var pattern = @"<span[^>]*class=""[^""]*x2b8uid[^""]*""[^>]*>(.*?)</span>";
                                         var match = Regex.Match(bodyHtml, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
                                         code = match.Success ? match.Groups[1].Value.Trim() : string.Empty;
                                         if (string.IsNullOrEmpty(code))


### PR DESCRIPTION
## Summary
- correct regex pattern string literal in Program.cs to use proper quoting

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68bb5892af08832096c7d6c66cdb06bb