### PR TITLE
Fix WhatsApp code extraction from spans

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1207,9 +1207,9 @@ namespace MaxTelegramBot
                                                 ["awaitPromise"] = true
                                         });
                                         var bodyHtml = resp?["result"]?["value"]?.ToString() ?? string.Empty;
-                                        var pattern = @"<span[^>]*class=""[^""]*x2b8uid[^""]*""[^>]*>(.*?)</span>";
-                                        var match = Regex.Match(bodyHtml, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-                                        code = match.Success ? match.Groups[1].Value.Trim() : string.Empty;
+                                        var pattern = @"<span[^>]*class=""[^""]*x2b8uid[^""]*xk50ysn[^""]*x1aueamr[^""]*x1jzgpr8[^""]*xzwifym[^""]*""[^>]*>(.*?)</span>";
+                                        var matches = Regex.Matches(bodyHtml, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                                        code = string.Concat(matches.Cast<Match>().Select(m => m.Groups[1].Value.Trim()));
                                         if (string.IsNullOrEmpty(code))
                                                 await Task.Delay(500);
                                 }


### PR DESCRIPTION
## Summary
- Collect WhatsApp verification code by concatenating text from all span elements with specific class names.

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68bb5b21a8c08320ba92f7dbc835ac49