### PR TITLE
feat: support deep text extraction

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -362,10 +362,8 @@ namespace MaxTelegramBot
 
                 public async Task<string?> GetTextBySelectorAsync(string cssSelector)
                 {
-                        var expr = "(function(sel){var nodes=document.querySelectorAll(sel);" +
-                                   "if(!nodes||nodes.length===0) return '';" +
-                                   "return Array.from(nodes).map(n => (n.textContent||'').trim()).join('');" +
-                                   "})('" + EscapeJs(cssSelector) + "')";
+                        var expr = BuildDeepQueryExpression(cssSelector,
+                                "return el ? (el.textContent || '').trim() : '';");
                         var resp = await SendAsync("Runtime.evaluate", new JObject
                         {
                                 ["expression"] = expr,


### PR DESCRIPTION
## Summary
- retrieve text via BuildDeepQueryExpression so nested shadow DOM and iframes are supported

## Testing
- `dotnet build`
- `node test_get_text.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc8a31d41c832097497899bbade688