### PR TITLE
Improve text retrieval to traverse iframes

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -363,7 +363,9 @@ namespace MaxTelegramBot
                 public async Task<string?> GetTextBySelectorAsync(string cssSelector)
                 {
                         var expr = BuildDeepQueryExpression(cssSelector,
-                                "return el ? (el.textContent || '').trim() : '';");
+                                "if(!el) return ''; var nodes=el.ownerDocument.querySelectorAll(sel); " +
+                                "var res=[]; for(var i=0;i<nodes.length;i++){var t=nodes[i].textContent; " +
+                                "if(t) res.push(t.trim());} return res.join('');");
                         var resp = await SendAsync("Runtime.evaluate", new JObject
                         {
                                 ["expression"] = expr,


### PR DESCRIPTION
## Summary
- Gather text from all selector matches across shadow DOM/iframes using `BuildDeepQueryExpression`

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68bc8ca47c808320992ad79ffab28591