### PR TITLE
Simplify deep selector text retrieval

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -363,13 +363,11 @@ namespace MaxTelegramBot
                 public async Task<string?> GetTextBySelectorAsync(string cssSelector)
                 {
                         var expr = BuildDeepQueryExpression(cssSelector,
-                                "if(!el) return ''; var res=[];" +
-                                "function collect(root){var list;try{list=root.querySelectorAll(sel);}catch(e){list=[];}" +
+                                "if(!el) return '';" +
+                                "var list=el.ownerDocument.querySelectorAll(sel);" +
+                                "var res=[];" +
                                 "for(var i=0;i<list.length;i++){var t=list[i].textContent; if(t) res.push(t.trim());}" +
-                                "var children=root.querySelectorAll('*'); for(var i=0;i<children.length;i++){var node=children[i];" +
-                                "try{var cd=node.contentDocument; if(cd) collect(cd);}catch(e){}" +
-                                "var sr=node.shadowRoot; if(sr) collect(sr);}}" +
-                                "collect(el.ownerDocument); return res.join('');");
+                                "return res.join('');");
                         var resp = await SendAsync("Runtime.evaluate", new JObject
                         {
                                 ["expression"] = expr,


### PR DESCRIPTION
## Summary
- Simplify deep text extraction logic to query through `BuildDeepQueryExpression`
- Use `__maxFind` to locate elements and collect text via `querySelectorAll`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc910b2e6083208b308672407b91a7