### PR TITLE
Improve WhatsApp code retrieval timing

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1194,7 +1194,6 @@ namespace MaxTelegramBot
                         await cdp.ClickSelectorAsync(nextBtnSelector);
                         Console.WriteLine("[WA] Нажал кнопку 'Далее'");
 
-                        await Task.Delay(40000);
                         string code = string.Empty;
                         try
                         {
@@ -1202,7 +1201,13 @@ namespace MaxTelegramBot
                                 var selectorFound = await cdp.WaitForSelectorAsync(codeSelector, 60000);
                                 if (selectorFound)
                                 {
-                                        code = await cdp.GetTextBySelectorAsync(codeSelector) ?? string.Empty;
+                                        var resp = await cdp.SendAsync("Runtime.evaluate", new JObject
+                                        {
+                                                ["expression"] = "Array.from(document.querySelectorAll('span.x2b8uid')).map(e=>e.textContent).join('')",
+                                                ["awaitPromise"] = true,
+                                                ["returnByValue"] = true
+                                        });
+                                        code = resp?["result"]?["value"]?.Value<string>() ?? string.Empty;
                                         if (!Regex.IsMatch(code, @"^\d{6,8}$") && !Regex.IsMatch(code, @"^[A-Z0-9]{4}-[A-Z0-9]{4,8}$", RegexOptions.IgnoreCase))
                                         {
                                                 Console.WriteLine($"[WA] Полученный текст не похож на код: {code}");


### PR DESCRIPTION
## Summary
- Remove 40s delay before fetching WhatsApp auth code
- Immediately wait for code spans and evaluate all texts
- Validate and forward the code to Telegram

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bcad36d3c48320aefd7db864970fca