### PR TITLE
Detect WhatsApp code without selector

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -378,6 +378,17 @@ namespace MaxTelegramBot
                         return resp?["result"]?["value"]?.Value<string>();
                 }
 
+                public async Task<string?> GetBodyTextAsync()
+                {
+                        var resp = await SendAsync("Runtime.evaluate", new JObject
+                        {
+                                ["expression"] = "document.body ? document.body.innerText : ''",
+                                ["awaitPromise"] = true,
+                                ["returnByValue"] = true
+                        });
+                        return resp?["result"]?["value"]?.Value<string>();
+                }
+
 		public async Task<bool> FillOtpInputsAsync(string digits)
 		{
 			var expr = "(function(code){"+


### PR DESCRIPTION
## Summary
- add `GetBodyTextAsync` to retrieve full page text
- scan page text with regex to find WhatsApp login code instead of using a fragile selector

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bf7cebda088320914660864cb093d7