### PR TITLE
Improve login button click reliability

### DIFF
--- a/MaxWebAutomation.cs
+++ b/MaxWebAutomation.cs
@@ -203,16 +203,17 @@ namespace MaxTelegramBot
 			});
 		}
 
-                public async Task ClickSelectorAsync(string cssSelector)
+                public async Task<bool> ClickSelectorAsync(string cssSelector)
                 {
                         var expr = BuildDeepQueryExpression(cssSelector,
                                 "if(el){el.click(); return true;} return false;");
-                        await SendAsync("Runtime.evaluate", new JObject
+                        var resp = await SendAsync("Runtime.evaluate", new JObject
                         {
                                 ["expression"] = expr,
                                 ["awaitPromise"] = true,
                                 ["returnByValue"] = true
                         });
+                        return resp?["result"]?["value"]?.Value<bool?>() == true;
                 }
 
                 public async Task<bool> ClickSelectorByMouseAsync(string cssSelector)

--- a/Program.cs
+++ b/Program.cs
@@ -382,17 +382,21 @@ namespace MaxTelegramBot
                 }
                 
                 Console.WriteLine("[MAX] Начинаю ввод номера...");
-				const string inputSelector = "input.field.svelte-12ka1eq";
-				await cdp.FocusSelectorAsync(inputSelector);
-				await cdp.ClearInputAsync(inputSelector);
-				await cdp.TypeTextAsync(digits);
-				Console.WriteLine($"[MAX] Ввел номер {digits}");
+                                const string inputSelector = "input.field";
+                                await cdp.FocusSelectorAsync(inputSelector);
+                                await cdp.ClearInputAsync(inputSelector);
+                                await cdp.TypeTextAsync(digits);
+                                Console.WriteLine($"[MAX] Ввел номер {digits}");
 
-				// Кликаем по кнопке Войти
-				const string submitSelector = "button.button.button--large.button--neutral-primary.button--stretched.svelte-1nz7ayb";
-				await Task.Delay(300);
-				await cdp.ClickSelectorAsync(submitSelector);
-				Console.WriteLine("[MAX] Нажал кнопку Войти");
+                                // Кликаем по кнопке "Войти" (по тексту), при необходимости используем резервный селектор
+                                await Task.Delay(300);
+                                bool clicked = await cdp.ClickButtonByTextAsync("Войти");
+                                if (!clicked)
+                                {
+                                    const string submitSelector = "button.button.button--large.button--neutral-primary.button--stretched";
+                                    clicked = await cdp.ClickSelectorAsync(submitSelector);
+                                }
+                                Console.WriteLine(clicked ? "[MAX] Нажал кнопку Войти" : "[MAX] Не удалось нажать кнопку Войти");
 
 				                // Проверяем на капчу после ввода номера
                 Console.WriteLine("[MAX] Проверяю на капчу после ввода номера...");


### PR DESCRIPTION
## Summary
- Avoid dynamic Svelte classes when entering the phone number and clicking **Войти**, falling back to a generic selector if needed
- Return click success state from `ClickSelectorAsync` to detect failures

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68c571cf6454832cb1c0a0852253af68